### PR TITLE
Respect values in config file with argparse defaults

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,3 @@
+## [unreleased]
+
+- Fix bug where values in config file with argparse defaults were not respected (#2)

--- a/markusmoss/cli.py
+++ b/markusmoss/cli.py
@@ -7,6 +7,14 @@ from .markusmoss import MarkusMoss
 DEFAULTRC = "markusmossrc"
 
 
+DEFAULTS = {
+    "workdir": os.getcwd(),
+    "language": mosspy.Moss.languages,
+    "file_glob": "**/*",
+    "html_parser": "html.parser"
+}
+
+
 def _parse_config(pre_args):
     args_dict = vars(pre_args).copy()
     if os.path.isfile(pre_args.config):
@@ -15,6 +23,9 @@ def _parse_config(pre_args):
         for key, value in config_args.items():
             if args_dict.get(key) is None:
                 args_dict[key] = value
+    for key, value in DEFAULTS.items():
+        if args_dict.get(key) is None:
+            args_dict[key] = value
     return args_dict
 
 
@@ -26,11 +37,12 @@ def _parse_args():
     parser.add_argument("--moss-userid")
     parser.add_argument("--moss-report-url")
     parser.add_argument("--config", default=os.path.join(os.getcwd(), DEFAULTRC))
-    parser.add_argument("--workdir", default=os.getcwd())
+    parser.add_argument("--workdir")
     parser.add_argument("--actions", nargs="*", default=None, choices=MarkusMoss.ACTIONS)
-    parser.add_argument("--language", choices=mosspy.Moss.languages)
-    parser.add_argument("--file-glob", default="**/*")
-    parser.add_argument("--html-parser", default="html.parser")
+    parser.add_argument("--language")
+    parser.add_argument("--file-glob")
+    parser.add_argument("--html-parser")
+    parser.add_argument("--groups", nargs="*", default=None)
     parser.add_argument("-f", "--force", action="store_true")
     parser.add_argument("-v", "--verbose", action="store_true")
 


### PR DESCRIPTION
This fixes a bug where values specified in the config file were not being used if an argument had a default value (from argparse)